### PR TITLE
Refactor copy code to reduce overhead for non-batched

### DIFF
--- a/clients/include/testing_copy_batched.hpp
+++ b/clients/include/testing_copy_batched.hpp
@@ -60,7 +60,7 @@ void testing_copy_batched(const Arguments& arg)
             return;
         }
 
-        if(batch_count < 0)
+        if(N > 0 && batch_count < 0)
             EXPECT_ROCBLAS_STATUS(
                 rocblas_copy_batched<T>(handle, N, dx, incx, dy, incy, batch_count),
                 rocblas_status_invalid_size);

--- a/clients/include/testing_copy_strided_batched.hpp
+++ b/clients/include/testing_copy_strided_batched.hpp
@@ -75,7 +75,7 @@ void testing_copy_strided_batched(const Arguments& arg)
             return;
         }
 
-        if(batch_count < 0)
+        if(N > 0 && batch_count < 0)
             EXPECT_ROCBLAS_STATUS(
                 rocblas_copy_strided_batched<T>(
                     handle, N, dx, incx, stride_x, dy, incy, stride_y, batch_count),

--- a/library/src/blas1/rocblas_copy.cpp
+++ b/library/src/blas1/rocblas_copy.cpp
@@ -29,6 +29,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_copy_name<T>, n, x, incx, y, incy);

--- a/library/src/blas1/rocblas_copy.cpp
+++ b/library/src/blas1/rocblas_copy.cpp
@@ -47,15 +47,7 @@ namespace
         if(layer_mode & rocblas_layer_mode_log_profile)
             log_profile(handle, rocblas_copy_name<T>, "N", n, "incx", incx, "incy", incy);
 
-        if(!x || !y)
-            return rocblas_status_invalid_pointer;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
-
-        if(!incx || !incy)
-            return rocblas_status_invalid_size;
-
-        return rocblas_copy_template<NB, T>(handle, n, x, 0, incx, 0, y, 0, incy, 0, 1);
+        return rocblas_copy_template<NB, false, T>(handle, n, x, 0, incx, 0, y, 0, incy, 0, 1);
     }
 
 } // namespace

--- a/library/src/blas1/rocblas_copy.hpp
+++ b/library/src/blas1/rocblas_copy.hpp
@@ -59,17 +59,19 @@ rocblas_status rocblas_copy_template(rocblas_handle handle,
     if(batch_count < 0)
         return rocblas_status_invalid_size;
 
-    int  blocks = (n - 1) / NB + 1;
-    dim3 grid(blocks, batch_count);
-    dim3 threads(NB);
-
     if(!BATCH_ADJUSTXY)
     {
+        if(incx == incy && x == y)
+            return rocblas_status_success;
         if(incx < 0)
             x -= ptrdiff_t(incx) * (n - 1);
         if(incy < 0)
             y -= ptrdiff_t(incy) * (n - 1);
     }
+
+    int  blocks = (n - 1) / NB + 1;
+    dim3 grid(blocks, batch_count);
+    dim3 threads(NB);
 
     hipLaunchKernelGGL((copy_kernel<BATCH_ADJUSTXY, T>),
                        grid,

--- a/library/src/blas1/rocblas_copy.hpp
+++ b/library/src/blas1/rocblas_copy.hpp
@@ -49,8 +49,6 @@ rocblas_status rocblas_copy_template(rocblas_handle handle,
                                      rocblas_stride stridey,
                                      rocblas_int    batch_count)
 {
-    RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
-
     // Quick return if possible.
     if(n <= 0 || !batch_count)
         return rocblas_status_success;

--- a/library/src/blas1/rocblas_copy_batched.cpp
+++ b/library/src/blas1/rocblas_copy_batched.cpp
@@ -34,6 +34,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_copy_batched_name<T>, n, x, incx, y, incy, batch_count);

--- a/library/src/blas1/rocblas_copy_batched.cpp
+++ b/library/src/blas1/rocblas_copy_batched.cpp
@@ -63,15 +63,8 @@ namespace
                         "batch_count",
                         batch_count);
 
-        if(!x || !y)
-            return rocblas_status_invalid_pointer;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
-
-        if(!incx || !incy || batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        return rocblas_copy_template<NB, T>(handle, n, x, 0, incx, 0, y, 0, incy, 0, batch_count);
+        return rocblas_copy_template<NB, true, T>(
+            handle, n, x, 0, incx, 0, y, 0, incy, 0, batch_count);
     }
 
 } // namespace

--- a/library/src/blas1/rocblas_copy_strided_batched.cpp
+++ b/library/src/blas1/rocblas_copy_strided_batched.cpp
@@ -85,15 +85,7 @@ namespace
                         "batch_count",
                         batch_count);
 
-        if(!x || !y)
-            return rocblas_status_invalid_pointer;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
-
-        if(!incx || !incy || batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        return rocblas_copy_template<NB, T>(
+        return rocblas_copy_template<NB, true, T>(
             handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
     }
 

--- a/library/src/blas1/rocblas_copy_strided_batched.cpp
+++ b/library/src/blas1/rocblas_copy_strided_batched.cpp
@@ -85,7 +85,7 @@ namespace
                         "batch_count",
                         batch_count);
 
-        return rocblas_copy_template<NB, true, T>(
+        return rocblas_copy_template<NB, false, T>(
             handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
     }
 

--- a/library/src/blas1/rocblas_copy_strided_batched.cpp
+++ b/library/src/blas1/rocblas_copy_strided_batched.cpp
@@ -39,6 +39,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle,

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -72,12 +72,6 @@ __forceinline__ __device__ __host__ rocblas_half2 load_scalar(const rocblas_half
 
 // For device side array of scalars
 template <typename T>
-__forceinline__ __device__ __host__ T load_scalar(const T* x, rocblas_int idx, rocblas_int inc)
-{
-    return x[idx * inc];
-}
-
-template <typename T>
 __forceinline__ __device__ __host__ T load_scalar(T* x, rocblas_int idx, rocblas_int inc)
 {
     return x[idx * inc];


### PR DESCRIPTION
Refactor copy code to reduce overhead for the non-batched case, simplify code, and enable short-circuit exits when `n <= 0`.

1. When `n <= 0`, we need quick exit with success, without any other error checking. If `n <= 0`, then `batch_count` does not matter, and won't be checked. There is a JIRA ticket open on this issue and I will need to go through all of the rest of the BLAS to make sure we honor "short-circuit success exits".
2. An extra `bool` template parameter, `BATCH_ADJUSTXY`, is added to `copy_kernel`, to indicate whether `x` and `y` are adjusted according to `incx` and `incy` for each batch. If `BATCH_ADJUSTXY` is false, then it is assumed there is only one batch, and that `x` and `y` have already been adjusted.

    (**Note:** `constexpr if` would be used if this were C++17; but instead, the code is compilable even when `BATCH_ADJUSTXY` is `false`, and the compiler optimizes the code away because the `if` condition is constant.)
3. The same `BATCH_ADJUSTXY` template parameter is added to `rocblas_copy_template`, and the adjustments of `x` and `y` are done there, if `BATCH_ADJUSTXY` is false.
4. All argument error checks and the `RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED` device memory query, are moved to `rocblas_copy_template`, and so the `*_impl` functions are simplified.
5. An extra overload of `load_scalar` in `utility.h` has been removed as redundant. There was already an existing overload, the only difference being that the removed one had `const T*` instead of `T*` as the function parameter. Template argument deduction is able to deduce `T` as `const` when it's `const`, and non-`const` when it's non-`const`.
 
@mahmoodw @TorreZuk @amcamd @YvanMokwinski @daineAMD 